### PR TITLE
Fix/attendee limit appearing on limitless

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Comment;
 use App\Http\Requests\DeleteCommentRequest;
 use App\GrowthSession;
+use App\Http\Resources\GrowthSession as GrowthSessionResource;
 use Illuminate\Http\Request;
 
 class CommentController extends Controller
@@ -20,7 +21,7 @@ class CommentController extends Controller
         $comment->user()->associate($request->user());
         $comment->growthSession()->associate($growthSession);
         $comment->save();
-        return $growthSession->fresh();
+        return new GrowthSessionResource($growthSession->fresh());
     }
 
     public function destroy(DeleteCommentRequest $request, GrowthSession $growthSession,Comment $comment)

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -28,6 +28,6 @@ class CommentController extends Controller
     {
         $comment->delete();
 
-        return $growthSession->fresh();
+        return new GrowthSessionResource($growthSession->fresh());
     }
 }

--- a/tests/Feature/CommentsTest.php
+++ b/tests/Feature/CommentsTest.php
@@ -22,13 +22,30 @@ class CommentsTest extends TestCase
         $this->assertNotEmpty($growthSession->fresh()->comments);
     }
 
-    public function testItReturnsTheGrowthSessionForThatContainsTheNewlyCreatedComment()
+    public function testItReturnsGrowthSessionResourceOnCommentSubmission()
     {
         $user = User::factory()->create();
         $limitlessSession = GrowthSession::factory()->create(['attendee_limit' => GrowthSession::NO_LIMIT]);
 
         $this->actingAs($user)
             ->postJson(route('growth_sessions.comments.store', $limitlessSession), ['content' => 'Hello world'])
+            ->assertJsonMissing(['attendee_limit' => GrowthSession::NO_LIMIT]);
+    }
+
+    public function testItReturnsGrowthSessionResourceOnCommentDestroy()
+    {
+        GrowthSession::factory()
+            ->has(Comment::factory())
+            ->create(['attendee_limit' => GrowthSession::NO_LIMIT]);
+
+        $targetComment = Comment::query()->first();
+
+        $this->actingAs($targetComment->user)
+            ->deleteJson(
+                route('growth_sessions.comments.destroy', [
+                        'social_mob' => $targetComment->growthSession,
+                        'comment' => $targetComment
+                    ]))
             ->assertJsonMissing(['attendee_limit' => GrowthSession::NO_LIMIT]);
     }
 

--- a/tests/Feature/CommentsTest.php
+++ b/tests/Feature/CommentsTest.php
@@ -22,6 +22,16 @@ class CommentsTest extends TestCase
         $this->assertNotEmpty($growthSession->fresh()->comments);
     }
 
+    public function testItReturnsTheGrowthSessionForThatContainsTheNewlyCreatedComment()
+    {
+        $user = User::factory()->create();
+        $limitlessSession = GrowthSession::factory()->create(['attendee_limit' => GrowthSession::NO_LIMIT]);
+
+        $this->actingAs($user)
+            ->postJson(route('growth_sessions.comments.store', $limitlessSession), ['content' => 'Hello world'])
+            ->assertJsonMissing(['attendee_limit' => GrowthSession::NO_LIMIT]);
+    }
+
     public function testItDoesNotAllowGuestsToPostComments()
     {
         $growthSession = GrowthSession::factory()->create();


### PR DESCRIPTION
Fix bug that caused attendee limit to appear whenever a comment was created or deleted. 

See: https://github.com/vehikl/vehikl-growth-sessions/issues/84