### PR TITLE
Discord Channel Filter

### DIFF
--- a/app/Http/Resources/DiscordChannelCollection.php
+++ b/app/Http/Resources/DiscordChannelCollection.php
@@ -8,4 +8,11 @@ class DiscordChannelCollection extends ResourceCollection
 {
     /** @var string */
     public $collects = DiscordChannel::class;
+
+    public function toArray($request)
+    {
+        return $this->collection
+            ->sortBy(fn(DiscordChannel $discordChannel) => strtolower($discordChannel->resource->name))
+            ->toArray();
+    }
 }

--- a/app/Services/Discord/DiscordService.php
+++ b/app/Services/Discord/DiscordService.php
@@ -14,8 +14,6 @@ class DiscordService
             'https://discord.com/api/guilds/' . config('services.discord.guild_id') . '/channels'
         )->json();
 
-        dd($channels);
-
         return collect($channels)
             ->filter(function (array $channel) {
                 return $channel['parent_id'] !== config('services.discord.vidya_id')

--- a/app/Services/Discord/DiscordService.php
+++ b/app/Services/Discord/DiscordService.php
@@ -14,8 +14,13 @@ class DiscordService
             'https://discord.com/api/guilds/' . config('services.discord.guild_id') . '/channels'
         )->json();
 
+        dd($channels);
+
         return collect($channels)
-            ->filter(fn(array $channel) => is_null($channel['parent_id']))
+            ->filter(function (array $channel) {
+                return $channel['parent_id'] !== config('services.discord.vidya_id')
+                    && $channel['id'] !== config('services.discord.vidya_id');
+            })
             ->map(fn(array $channel) => new Channel($channel['id'], $channel['name']));
     }
 }

--- a/app/Services/Discord/DiscordService.php
+++ b/app/Services/Discord/DiscordService.php
@@ -14,6 +14,8 @@ class DiscordService
             'https://discord.com/api/guilds/' . config('services.discord.guild_id') . '/channels'
         )->json();
 
-        return collect($channels)->map(fn($channel) => new Channel($channel['id'], $channel['name']));
+        return collect($channels)
+            ->filter(fn(array $channel) => is_null($channel['parent_id']))
+            ->map(fn(array $channel) => new Channel($channel['id'], $channel['name']));
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -44,6 +44,7 @@ return [
     'discord' => [
         'guild_id' => env('DISCORD_GUILD_ID'),
         'bot_token' => env('DISCORD_BOT_TOKEN'),
+        'vidya_id' => env('DISCORD_VIDYA_ID'),
     ],
 
 ];

--- a/tests/Feature/Api/DiscordChannelsTest.php
+++ b/tests/Feature/Api/DiscordChannelsTest.php
@@ -46,6 +46,39 @@ class DiscordChannelsTest extends TestCase
         });
     }
 
+    public function testItAlphabetizesDiscordChannels(): void
+    {
+        $fakeChannels = collect([
+            new Channel('1234567890', 'Alpha'),
+            new Channel('1234567891', 'Charlie'),
+            new Channel('1234567892', 'bravo'),
+            new Channel('1234567893', 'Delta'),
+        ]);
+
+        $this->mockedDiscord->method('getChannels')
+            ->willReturn($fakeChannels);
+
+        $response = $this->actingAs(User::factory()->create())->get('/api/discord-channels');
+        $response->assertExactJson([
+            [
+                'id' => '1234567890',
+                'name' => 'Alpha',
+            ],
+            [
+                'id' => '1234567892',
+                'name' => 'bravo',
+            ],
+            [
+                'id' => '1234567891',
+                'name' => 'Charlie',
+            ],
+            [
+                'id' => '1234567893',
+                'name' => 'Delta',
+            ],
+        ]);
+    }
+
     public function testItRedirectsIfUserIsNotLoggedIn(): void
     {
         $this->get('/api/discord-channels')->assertRedirect('/');

--- a/tests/Unit/Services/Discord/DiscordServiceTest.php
+++ b/tests/Unit/Services/Discord/DiscordServiceTest.php
@@ -19,7 +19,7 @@ class DiscordServiceTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        //config(['services.discord.guild_id' => $this->fakeDiscordGuildId]);
+        config(['services.discord.guild_id' => $this->fakeDiscordGuildId]);
         config(['services.discord.vidya_id' => $this->fakeVidyaCategoryId]);
     }
 
@@ -33,7 +33,7 @@ class DiscordServiceTest extends TestCase
 
     public function testItMakesAGetsRequestToDiscordForAllGuildVoiceChannels(): void
     {
-        //Http::fake();
+        Http::fake();
 
         $discord = new DiscordService();
 


### PR DESCRIPTION
Multiple Discord channels are grouped under 'Vidya' category -- meaning, they are for video games -- and as such, growth sessions probably shouldn't be taking place there. This PR will filter out any Discord channels under the 'Vidya' category. As a small bonus, it will also alphabetize channels coming out of the API.

This PR will require one additional .env variable, let me know via the Slacks when it's needed.