### PR TITLE
Solve "cards are not rendering" issue

### DIFF
--- a/resources/js/classes/WeekGrowthSessions.ts
+++ b/resources/js/classes/WeekGrowthSessions.ts
@@ -24,7 +24,7 @@ export class WeekGrowthSessions {
     }
 
     getSessionByDate(date: DateTime): GrowthSession[] {
-        return this.weekGrowthSessions[date.toDateString()] as GrowthSession[];
+        return this.weekGrowthSessions[date.toDateString()] as GrowthSession[] ?? [];
     }
 
     get isReady(): boolean {


### PR DESCRIPTION
Solves #139

Explanation:

When `getSessionByDate` method returns nothing, Vue will give the error because only array has `length` attribute. So instead of not returning, I made it to return empty array when needed.