### PR TITLE
Hide growth session topics for sessions that have past

### DIFF
--- a/resources/js/components/GrowthSessionCard.spec.ts
+++ b/resources/js/components/GrowthSessionCard.spec.ts
@@ -259,6 +259,14 @@ describe('GrowthSessionCard', () => {
         expect(wrapper.find('.copy-button').element).not.toBeVisible();
     });
 
+    it('does not display the growth session topic if the date of the growth session is in the past', () => {
+        const oneDayAfterTheGrowthSession = DateTime.parseByDate(growthSessionData.date).addDays(1).toISOString();
+        DateTime.setTestNow(oneDayAfterTheGrowthSession);
+        wrapper = mount(GrowthSessionCard, {propsData: {growthSession: growthSessionData, user: attendee}});
+
+        expect(wrapper.findComponent({ref: "growth-session-topic"}).element).not.toBeVisible();
+    });
+
     it('Emits a copy-requested event when the copy button is clicked', () => {
         wrapper.find('.copy-button').trigger('click');
 

--- a/resources/js/components/GrowthSessionCard.vue
+++ b/resources/js/components/GrowthSessionCard.vue
@@ -44,7 +44,8 @@
         <pre
             class="mb-4 inline-block text-left break-words-fixed whitespace-pre-wrap max-h-64 overflow-y-auto overflow-x-hidden font-sans"
             ref="growth-session-topic"
-            v-text="growthSession.topic"/>
+            v-text="growthSession.topic"
+            v-show="!growthSession.hasAlreadyHappened"/>
         <div class="flex items-center flex-1 mb-4 text-blue-700">
             <p class="mr-3">Host:</p>
             <p class="mr-6 text-md" v-text="growthSession.owner.name"/>


### PR DESCRIPTION
Addressing Issue: https://github.com/vehikl/vehikl-growth-sessions/issues/204

With Topics
![image](https://user-images.githubusercontent.com/19536179/235529791-0fce19a6-a9e3-4e36-850c-3278e423e863.png)

Without Topics
![image](https://user-images.githubusercontent.com/19536179/235529695-53ffe6d7-4bea-4111-9712-51526f50d621.png)

Would love feedback/suggestions